### PR TITLE
Add React offerte calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # deverbeelding-calculator
-Not sure what this will be yet
+
+Dit project bevat een eenvoudige React applicatie waarmee je snel een offerte kunt samenstellen. De applicatie staat in de map `offerte-calculator` en gebruikt React via een CDN, zodat er geen extra build-stap nodig is.
+
+## Gebruik
+
+Open `offerte-calculator/index.html` in een browser. Je kunt regels toevoegen met een omschrijving, aantal en prijs per stuk. Het totaalbedrag wordt automatisch bijgewerkt.

--- a/offerte-calculator/app.js
+++ b/offerte-calculator/app.js
@@ -1,0 +1,69 @@
+const { useState } = React;
+
+function App() {
+  const [items, setItems] = useState([{ description: '', quantity: 1, price: 0 }]);
+
+  const addItem = () => {
+    setItems([...items, { description: '', quantity: 1, price: 0 }]);
+  };
+
+  const updateItem = (index, field, value) => {
+    const newItems = [...items];
+    newItems[index][field] = value;
+    setItems(newItems);
+  };
+
+  const total = items.reduce((sum, item) => sum + item.quantity * item.price, 0);
+
+  return (
+    React.createElement('div', null,
+      React.createElement('h1', null, 'Offerte Calculator'),
+      React.createElement('table', null,
+        React.createElement('thead', null,
+          React.createElement('tr', null,
+            React.createElement('th', null, 'Omschrijving'),
+            React.createElement('th', null, 'Aantal'),
+            React.createElement('th', null, 'Prijs per stuk'),
+            React.createElement('th', null, 'Subtotaal')
+          )
+        ),
+        React.createElement('tbody', null,
+          items.map((item, index) =>
+            React.createElement('tr', { key: index },
+              React.createElement('td', null,
+                React.createElement('input', {
+                  type: 'text',
+                  value: item.description,
+                  onChange: e => updateItem(index, 'description', e.target.value)
+                })
+              ),
+              React.createElement('td', null,
+                React.createElement('input', {
+                  type: 'number',
+                  min: 0,
+                  value: item.quantity,
+                  onChange: e => updateItem(index, 'quantity', Number(e.target.value))
+                })
+              ),
+              React.createElement('td', null,
+                React.createElement('input', {
+                  type: 'number',
+                  step: '0.01',
+                  min: 0,
+                  value: item.price,
+                  onChange: e => updateItem(index, 'price', Number(e.target.value))
+                })
+              ),
+              React.createElement('td', null, (item.quantity * item.price).toFixed(2))
+            )
+          )
+        )
+      ),
+      React.createElement('button', { onClick: addItem }, 'Regel toevoegen'),
+      React.createElement('h2', null, `Totaal: €${total.toFixed(2)}`)
+    )
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(React.createElement(App));

--- a/offerte-calculator/index.html
+++ b/offerte-calculator/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Offerte Calculator</title>
+  <link rel="stylesheet" href="style.css" />
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script defer src="app.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/offerte-calculator/style.css
+++ b/offerte-calculator/style.css
@@ -1,0 +1,29 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 40px;
+}
+
+h1 {
+  color: #333;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+td,
+th {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+
+button {
+  margin-top: 15px;
+  padding: 8px 12px;
+}
+
+input[type="number"] {
+  width: 80px;
+}


### PR DESCRIPTION
## Summary
- create `offerte-calculator` directory with a simple React app
- add HTML, JavaScript and CSS for a quote calculator
- update README with instructions

## Testing
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_68867d6f35d8832b8a4ab61c0113b8c4